### PR TITLE
Bugfix: configuration warning

### DIFF
--- a/pytorch_shearlets/utils.py
+++ b/pytorch_shearlets/utils.py
@@ -159,7 +159,7 @@ def SLcheckFilterSizes(rows,cols, shearLevels,directionalFilter,scalingFilter,
     if success == 0:
         sys.exit("The specified Shearlet system is not available for data of size "
             + str(rows) + "x" + str(cols) + ". Try decreasing the number of scales and shearings.")
-    if success == 1 and k>1:
+    if success == 1 and k>0:
         print("Warning: The specified Shearlet system was not available for data of size " + str(rows) + "x" + str(cols) + ". Filters were automatically set to configuration " + str(k) + "(see SLcheckFilterSizes).")
         return directionalFilter, scalingFilter, waveletFilter, scalingFilter2
     else:


### PR DESCRIPTION
Currently a warning is given when a configuration other than the specified 0th or the 1st preset configuration is used. 
To me it seems the intention was to warn when a configuration other than the specified configuration (0th configuration) is used.