### PR TITLE
Bugfix: SLpadArray dimension incompatiblity

### DIFF
--- a/pytorch_shearlets/utils.py
+++ b/pytorch_shearlets/utils.py
@@ -671,7 +671,7 @@ def SLpadArray(array, newSize):
             paddedArray[padSizes[1], padSizes[0]:padSizes[0]+currSize[0]+idxModifier[0]] = array
         else:
             paddedArray[padSizes[0]-idxModifier[0]:padSizes[0]+currSize[0]-idxModifier[0],
-                    padSizes[1]:padSizes[1]+currSize[1]+idxModifier[1]] = array
+                    padSizes[1]+idxModifier[1]:padSizes[1]+currSize[1]+idxModifier[1]] = array
     return paddedArray
 
 


### PR DESCRIPTION
Bug found when working with a scaling filter of size 32 and an image of dimensions 400x400. 

In function SLpadArray(array, newSize):
For certain combinations of scaling filter sizes and image dimensions, the replacement of zeros in the zero-padded Array with the original array elements fails as dimensions of the zero-array do not match the dimensions of the original array. 

It seems addition of idxModifier[1] in the lower bound of the slice was forgotten here, resulting in, for example, a (1,33) slice when adding a (1,32) array for an image of 400x400. 