### PR TITLE
Remove slice unpack

### DIFF
--- a/pytorch_shearlets/utils.py
+++ b/pytorch_shearlets/utils.py
@@ -850,7 +850,7 @@ def down2D(t, d,dims=(-2,-1)):
     colIdxs = [slice(None)]*ndims
     colIdxs[dims[1]] = slice(0,W,d)
     
-    return t[*rowIdxs][*colIdxs]
+    return t[rowIdxs][colIdxs]
 
 
 def up2D(t,d,dims=(-2,-1)):
@@ -887,7 +887,7 @@ def up2D(t,d,dims=(-2,-1)):
 
     device = t.device 
     r = torch.zeros(newshape,device=device)
-    r[*rowIdxs][*colIdxs] = t 
+    r[rowIdxs][colIdxs] = t 
 
     return r
     


### PR DESCRIPTION
Unpacking list of slices is not necessary for the desired functionality, but it does introduce incompatibility issues with python 3.10. Hence why it can and should be adjusted.